### PR TITLE
filter unused plugins

### DIFF
--- a/lib/common/plugins.js
+++ b/lib/common/plugins.js
@@ -44,5 +44,5 @@ module.exports = function initPlugins(flow, plugins){
       plugin.build(initPluginApi(flow, pluginCfg), pluginCfg.options || {});
       return pluginCfg.name;
     }
-  });
+  }).filter(Boolean);
 };


### PR DESCRIPTION
If plugin has no build section it appears as undefined in build output

[screenshot](https://cloud.githubusercontent.com/assets/1822939/12946369/b966a25c-d015-11e5-8d21-bbc8212a87db.png)
