### PR TITLE
Use digest as filename for culture packages

### DIFF
--- a/lib/build/l10n/makePackages.js
+++ b/lib/build/l10n/makePackages.js
@@ -110,17 +110,18 @@ var js_at = require('basisjs-tools-ast').js;
       var file = flow.files.add({
         type: 'culture',
         generated: true,
-        outputFilename: 'res/' + culture + '.culture',
         outputContent: JSON.stringify(packageContent[culture])
       });
 
+      file.outputFilename = 'res/' + file.digest + '.culture';
+
       packages[culture] = {
         cacheKey: storagePrefix + ':' + culture,
-        filename: './res/' + culture + '.culture?' + file.digest,
+        filename: './res/' + file.digest + '.culture',
         digest: file.digest
       };
 
-      fconsole.log(packages[culture].filename);
+      fconsole.log(packages[culture].filename + ' (' + culture + ')');
     }
 
   fconsole.endl();


### PR DESCRIPTION
Use digest as filename for culture package to avoid some issues with cache invalidation