### PR TITLE
csstree token loc normalization

### DIFF
--- a/lib/extract/css/index.js
+++ b/lib/extract/css/index.js
@@ -84,6 +84,15 @@ function dropThemes(file, stack){
 
 function processFile(file, flow){
   function correctLoc(loc){ // TODO: find out why we need this
+    // normalize css-tree tokens location
+    if (loc && loc.start)
+      loc = {
+        line: loc.start.line,
+        column: loc.start.column,
+        offset: loc.start.offset,
+        source: loc.source || '<unknown>'
+      };
+
     if (loc && offsetMap)
       if (loc.offset in offsetMap)
       {


### PR DESCRIPTION
The **old** css parser token location was defined like:
```json
{ "line": "...", "column": "...", "offset": "...", "source": "..." }
```
The **new** css parser token location is defined like:
```json
{
  "start": { "line": "...", "column": "...", "offset": "..." },
  "end": { "line": "...", "column": "...", "offset": "..." },
  "source": "..."
}
```
Because of this, `file.location(...)` returns wrong location: `path/to/style.css::`
Because of this, we can't at least normally add any css file to the `ignoreWarnings` section of the build config.
Most likely there are more cases that based on wrong css-token location.