### PR TITLE
common/command: fixed list argument normalization

### DIFF
--- a/lib/common/command.js
+++ b/lib/common/command.js
@@ -9,14 +9,14 @@ function resolveCwd(value){
 }
 
 function list(name){
-  return function(value){
+  return function(){
     var list = this.values[name];
-    if (arguments.length > 1)
-      value = Array.prototype.slice.call(arguments);
+    var args = Array.prototype.slice.call(arguments);
+
     if (!list || list.fromConfig)
       list = [];
-    list = list.concat(value);
-    if (value && value.fromConfig)
+    list = list.concat(args);
+    if (args[0] && args[0].fromConfig)
       list.fromConfig = true;
     return list;
   };

--- a/lib/common/command.js
+++ b/lib/common/command.js
@@ -8,18 +8,14 @@ function resolveCwd(value){
   return path.resolve(process.env.PWD || process.cwd(), value);
 }
 
-function list(name){
-  return function(){
-    var list = this.values[name];
-    var args = Array.prototype.slice.call(arguments);
-
-    if (!list || list.fromConfig)
-      list = [];
-    list = list.concat(args);
-    if (args[0] && args[0].fromConfig)
-      list.fromConfig = true;
-    return list;
-  };
+function list(newValue, oldValue){
+  var list = oldValue;
+  if (!list || list.fromConfig)
+    list = [];
+  list = list.concat(newValue);
+  if (newValue && newValue.fromConfig)
+    list.fromConfig = true;
+  return list;
 }
 
 function buildConfig(command, config, configPath, presetPath){
@@ -59,7 +55,7 @@ function buildConfig(command, config, configPath, presetPath){
     switch (name)
     {
       case 'ignoreWarnings':
-        result.ignoreWarnings = Array.isArray(config[name]) ? config[name].slice() : [];
+        result.ignoreWarnings = Array.isArray(config.ignoreWarnings) ? config.ignoreWarnings.slice() : [config.ignoreWarnings];
         result.ignoreWarnings.fromConfig = true;
         break;
 
@@ -69,8 +65,8 @@ function buildConfig(command, config, configPath, presetPath){
         break;
 
       case 'theme':
-        result.theme = [Array.isArray(config.theme) ? config.theme : [config.theme]];
-        result.theme[0].fromConfig = true;
+        result.theme = Array.isArray(config.theme) ? config.theme : [config.theme];
+        result.theme.fromConfig = true;
         break;
 
       case 'preprocess':
@@ -123,8 +119,8 @@ module.exports = function(command, options){
       resolveCwd
     )
     .option('--js-cut-dev', 'Remove code marked as debug from JavaScript source (cut off lines after ;;; and /** @cut .. */)')
-    .option('--theme <name>', 'Which template themes to use (all by default)', list('theme'))
-    .option('--ignore-warnings <pattern>', 'Set file pattern to be ignored by linter', list('ignoreWarnings'));
+    .option('--theme <name>', 'Which template themes to use (all by default)', list)
+    .option('--ignore-warnings <pattern>', 'Set file pattern to be ignored by linter', list);
 
   if (options && options.preset)
     command

--- a/lib/common/command.js
+++ b/lib/common/command.js
@@ -11,6 +11,8 @@ function resolveCwd(value){
 function list(name){
   return function(value){
     var list = this.values[name];
+    if (arguments.length > 1)
+      value = Array.prototype.slice.call(arguments);
     if (!list || list.fromConfig)
       list = [];
     list = list.concat(value);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "basisjs-tools-ast": "~1.5.0",
     "basisjs-tools-config": "~1.1.0",
     "chalk": "~1.1.1",
-    "clap": "~1.1.0",
+    "clap": "^1.2.0",
     "es6-promise-polyfill": "^1.2.0",
     "fixed-width-string": "^1.0.0",
     "mime": "~1.3.4",


### PR DESCRIPTION
Config:
```json
{
  "build": {
      "sameFilenames": true,
      "tmplDefaultTheme": "app",
      "jsCutDev": true,
      "theme": "app tablet",
      "ignoreWarnings": [
        "/node_modules/**/*.js",
        "/node_modules/**/*.css",
        "/src/agent/app/template/icon.css",
        "/src/dealer/app/template/icon.css"
      ]
  }
}
```

Without this fix `ignoreWarnings` will normalize to `["/node_modules/**/*.js"]` because of https://github.com/lahmatiy/clap/blob/master/index.js#L593