### PR TITLE
replaced uglify-js to uglify-es

### DIFF
--- a/lib/build/command.js
+++ b/lib/build/command.js
@@ -4,6 +4,7 @@ var common = require('../common/command');
 var isChildProcess = typeof process.send == 'function'; // child process has send method
 var targets = ['fs', 'output-graph', 'none']; // first is default
 var jsBundleFormats = ['js', 'json'];
+var DEFAULT_PACK_CONFIG = { compress: { ecma: 5 }, output: { ecma: 5 } };
 
 function resolveCwd(value){
   return path.resolve(process.env.PWD || process.cwd(), value);
@@ -115,6 +116,18 @@ module.exports = clap.create('build', '[fileOrPreset]')
   })
   .option('--js-bundle-name <name>', 'Name of JavaScript bundle, i.e. filename without extension')
   .option('--js-pack', 'Compress JavaScript')
+  .option('--js-pack-config <config>', 'Options for uglify-es', function(config){
+    if (typeof config === 'string')
+      try {
+        return JSON.parse(config);
+      } catch(e) {
+        return DEFAULT_PACK_CONFIG;
+      }
+    else if (config && typeof config === 'object' && config.constructor === Object)
+      return config;
+
+    return DEFAULT_PACK_CONFIG;
+  }, DEFAULT_PACK_CONFIG)
   .option('--js-pack-cmd <string>', 'Command to launch JavaScript packer, should accept input in stdio and output result in stdout (`google-closure-compiler --charset UTF-8` by default)')
 
   // css

--- a/lib/build/command.js
+++ b/lib/build/command.js
@@ -115,7 +115,7 @@ module.exports = clap.create('build', '[fileOrPreset]')
   })
   .option('--js-bundle-name <name>', 'Name of JavaScript bundle, i.e. filename without extension')
   .option('--js-pack', 'Compress JavaScript')
-  .option('--js-pack-config <config>', 'Options for uglify-es', function(config){
+  .option('--js-pack-config <config>', 'Options for minifier (uglify-es is used for now)', function(config){
     if (typeof config === 'string')
       try {
         return JSON.parse(config);

--- a/lib/build/command.js
+++ b/lib/build/command.js
@@ -4,7 +4,6 @@ var common = require('../common/command');
 var isChildProcess = typeof process.send == 'function'; // child process has send method
 var targets = ['fs', 'output-graph', 'none']; // first is default
 var jsBundleFormats = ['js', 'json'];
-var DEFAULT_PACK_CONFIG = { compress: { ecma: 5 }, output: { ecma: 5 } };
 
 function resolveCwd(value){
   return path.resolve(process.env.PWD || process.cwd(), value);
@@ -121,13 +120,13 @@ module.exports = clap.create('build', '[fileOrPreset]')
       try {
         return JSON.parse(config);
       } catch(e) {
-        return DEFAULT_PACK_CONFIG;
+        return null;
       }
     else if (config && typeof config === 'object' && config.constructor === Object)
       return config;
 
-    return DEFAULT_PACK_CONFIG;
-  }, DEFAULT_PACK_CONFIG)
+    return null;
+  }, null)
   .option('--js-pack-cmd <string>', 'Command to launch JavaScript packer, should accept input in stdio and output result in stdout (`google-closure-compiler --charset UTF-8` by default)')
 
   // css

--- a/lib/build/js/pack.js
+++ b/lib/build/js/pack.js
@@ -151,5 +151,17 @@ function cmdProcess(file, flow, command, startFn, doneFn){
 
 function uglifyProcess(file, flow){
   flow.console.log('Compress ' + file.relOutputFilename);
-  file.outputContent = require('uglify-js').minify(file.outputContent).code;
+
+  var result = require('uglify-es').minify(file.outputContent);
+  var error = result.error;
+
+  if (error)
+    return flow.warn({
+      fatal: true,
+      message:
+      file.relOutputFilename + ':' + error.line + ':' + error.col + ' compression error:\n' +
+      error.message
+    });
+
+  file.outputContent = result.code;
 }

--- a/lib/build/js/pack.js
+++ b/lib/build/js/pack.js
@@ -152,15 +152,14 @@ function cmdProcess(file, flow, command, startFn, doneFn){
 function uglifyProcess(file, flow){
   flow.console.log('Compress ' + file.relOutputFilename);
 
-  var result = require('uglify-es').minify(file.outputContent, flow.options.jsPackConfig);
+  var DEFAULT_PACK_CONFIG = { compress: { ecma: 5 }, output: { ecma: 5 } };
+  var result = require('uglify-es').minify(file.outputContent, flow.options.jsPackConfig || DEFAULT_PACK_CONFIG);
   var error = result.error;
 
   if (error)
     return flow.warn({
       fatal: true,
-      message:
-      file.relOutputFilename + ':' + error.line + ':' + error.col + ' compression error:\n' +
-      error.message
+      message: file.relOutputFilename + ':' + error.line + ':' + error.col + ' compression error:\n' + error.message
     });
 
   file.outputContent = result.code;

--- a/lib/build/js/pack.js
+++ b/lib/build/js/pack.js
@@ -152,8 +152,8 @@ function cmdProcess(file, flow, command, startFn, doneFn){
 function uglifyProcess(file, flow){
   flow.console.log('Compress ' + file.relOutputFilename);
 
-  var DEFAULT_PACK_CONFIG = { compress: { ecma: 5 }, output: { ecma: 5 } };
-  var result = require('uglify-es').minify(file.outputContent, flow.options.jsPackConfig || DEFAULT_PACK_CONFIG);
+  var config = flow.options.jsPackConfig || { compress: { ecma: 5 }, output: { ecma: 5 } };
+  var result = require('uglify-es').minify(file.outputContent, config);
   var error = result.error;
 
   if (error)

--- a/lib/build/js/pack.js
+++ b/lib/build/js/pack.js
@@ -152,7 +152,7 @@ function cmdProcess(file, flow, command, startFn, doneFn){
 function uglifyProcess(file, flow){
   flow.console.log('Compress ' + file.relOutputFilename);
 
-  var result = require('uglify-es').minify(file.outputContent);
+  var result = require('uglify-es').minify(file.outputContent, flow.options.jsPackConfig);
   var error = result.error;
 
   if (error)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "minimatch": "^3.0.2",
     "resolve": "^1.1.7",
     "seedrandom": "~2.4.2",
-    "uglify-js": "^3.0.28"
+    "uglify-es": "^3.1.5"
   },
   "devDependencies": {
     "eslint": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "minimatch": "^3.0.2",
     "resolve": "^1.1.7",
     "seedrandom": "~2.4.2",
-    "uglify-es": "^3.1.5"
+    "uglify-es": "~3.1.8"
   },
   "devDependencies": {
     "eslint": "^2.2.0",


### PR DESCRIPTION
There is a node in [uglify-js](https://github.com/mishoo/UglifyJS2):

> Those wishing to minify ES2015+ (ES6+) should use the npm package uglify-es.

Closes #27